### PR TITLE
Add score+date sorting and posted-within date filter

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -564,7 +564,8 @@ class Database:
     async def list_jobs(self, sort_by="score", limit=50, offset=0, min_score=None,
                         search=None, source=None, dismissed=False,
                         work_type=None, employment_type=None, location=None,
-                        exclude_terms=None, region=None, clearance=None):
+                        exclude_terms=None, region=None, clearance=None,
+                        posted_within=None):
         query = """
             SELECT j.*, js.match_score, js.match_reasons, js.concerns, a.status as app_status
             FROM jobs j
@@ -623,8 +624,14 @@ class Database:
             elif clearance == "only":
                 query += f" AND ({clauses})"
             params.extend(clearance_terms)
+        if posted_within:
+            days_map = {"24h": 1, "3d": 3, "7d": 7, "14d": 14, "30d": 30}
+            days = days_map.get(posted_within)
+            if days:
+                query += " AND COALESCE(j.posted_date, j.created_at) >= datetime('now', ?)"
+                params.append(f"-{days} days")
         if sort_by == "score":
-            query += " ORDER BY js.match_score DESC NULLS LAST"
+            query += " ORDER BY js.match_score DESC NULLS LAST, COALESCE(j.posted_date, j.created_at) DESC"
         elif sort_by == "freshest":
             query += " ORDER BY COALESCE(j.posted_date, j.created_at) DESC"
         else:

--- a/app/main.py
+++ b/app/main.py
@@ -220,6 +220,7 @@ def create_app(db_path: str = "data/jobfinder.db", testing: bool = False) -> Fas
         location: str | None = Query(None),
         region: str | None = Query(None),
         clearance: str | None = Query(None),
+        posted_within: str | None = Query(None),
     ):
         config = await app.state.db.get_search_config()
         exclude_terms = config.get("exclude_terms", []) if config else []
@@ -229,6 +230,7 @@ def create_app(db_path: str = "data/jobfinder.db", testing: bool = False) -> Fas
             work_type=work_type, employment_type=employment_type,
             location=location, exclude_terms=exclude_terms,
             region=region, clearance=clearance,
+            posted_within=posted_within,
         )
         return {"jobs": jobs}
 

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -270,6 +270,14 @@ async function renderFeed(container) {
                 <option value="latam">Latin America</option>
                 <option value="apac">Asia-Pacific</option>
             </select>
+            <select class="filter-select" id="filter-posted-within">
+                <option value="">Any date</option>
+                <option value="24h">Last 24 hours</option>
+                <option value="3d">Last 3 days</option>
+                <option value="7d">Last 7 days</option>
+                <option value="14d">Last 2 weeks</option>
+                <option value="30d">Last 30 days</option>
+            </select>
             <select class="filter-select" id="filter-clearance">
                 <option value="">Any clearance</option>
                 <option value="hide">Hide clearance/visa required</option>
@@ -298,6 +306,7 @@ async function renderFeed(container) {
     const locationInput = document.getElementById('filter-location');
     const regionSelect = document.getElementById('filter-region');
     const clearanceSelect = document.getElementById('filter-clearance');
+    const postedWithinSelect = document.getElementById('filter-posted-within');
     const loadMoreBtn = document.getElementById('load-more-btn');
 
     let debounceTimer;
@@ -320,6 +329,7 @@ async function renderFeed(container) {
     employmentSelect.addEventListener('change', reload);
     regionSelect.addEventListener('change', reload);
     clearanceSelect.addEventListener('change', reload);
+    postedWithinSelect.addEventListener('change', reload);
     loadMoreBtn.addEventListener('click', () => loadJobs(true));
 
     // Select mode
@@ -375,6 +385,7 @@ async function loadJobs(append) {
         location: document.getElementById('filter-location')?.value || '',
         region: document.getElementById('filter-region')?.value || '',
         clearance: document.getElementById('filter-clearance')?.value || '',
+        posted_within: document.getElementById('filter-posted-within')?.value || '',
     };
 
     try {


### PR DESCRIPTION
## Summary

- Score sort now uses date as secondary sort — newest high-scored jobs appear first
- Added "posted within" dropdown filter with options: 24h, 3 days, 7 days, 2 weeks, 30 days
- Backend: new `posted_within` query parameter on `/api/jobs`, filters on `COALESCE(posted_date, created_at)`

## Test plan

- [x] All existing tests pass (36/36 in database + API tests)
- [ ] Verify job list sorts by score then date in UI
- [ ] Verify date filter correctly hides older listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)